### PR TITLE
히스토리를 나타내는 버튼에 스타일을 입혀서 보여준다

### DIFF
--- a/public/App.css
+++ b/public/App.css
@@ -54,3 +54,8 @@ ol, ul {
   margin:0;
   padding:0;
 }
+
+.highlight {
+  border: 2px solid;
+  border-color: yellow;
+}

--- a/public/App.css
+++ b/public/App.css
@@ -48,3 +48,9 @@ ol, ul {
 .game-info {
   margin-left: 20px;
 }
+
+.game-info-moves {
+  list-style-position:inside;
+  margin:0;
+  padding:0;
+}

--- a/ts/components/Game.tsx
+++ b/ts/components/Game.tsx
@@ -21,7 +21,7 @@ class Game extends React.Component<IProps, undefined> {
         'Move #' + move :
         'Game start';
         return (
-          <li style={{border: "2px solid yellow"}}key={move}>
+          <li style={this.props.stepNumber === move ? {border: "2px solid yellow"} : null}key={move}>
             <button onClick={() => this.props.jumpToHistory(move)}>{desc}</button>
           </li>
         );

--- a/ts/components/Game.tsx
+++ b/ts/components/Game.tsx
@@ -21,7 +21,7 @@ class Game extends React.Component<IProps, undefined> {
         'Move #' + move :
         'Game start';
         return (
-          <li style={this.props.stepNumber === move ? {border: "2px solid yellow"} : null}key={move}>
+          <li className={this.props.stepNumber === move ? "highlight" : ""} key={move}>
             <button onClick={() => this.props.jumpToHistory(move)}>{desc}</button>
           </li>
         );

--- a/ts/components/Game.tsx
+++ b/ts/components/Game.tsx
@@ -44,7 +44,7 @@ class Game extends React.Component<IProps, undefined> {
         </div>
         <div className="game-info">
           <div>{status}</div>
-          <ol style={{listStylePosition: "inside", margin: 0, padding: 0}}>{moves}</ol>
+          <ol className="game-info-moves">{moves}</ol>
         </div>
       </div>
     );

--- a/ts/components/Game.tsx
+++ b/ts/components/Game.tsx
@@ -21,7 +21,7 @@ class Game extends React.Component<IProps, undefined> {
         'Move #' + move :
         'Game start';
         return (
-          <li key={move}>
+          <li style={{border: "2px solid yellow"}}key={move}>
             <button onClick={() => this.props.jumpToHistory(move)}>{desc}</button>
           </li>
         );
@@ -44,7 +44,7 @@ class Game extends React.Component<IProps, undefined> {
         </div>
         <div className="game-info">
           <div>{status}</div>
-          <ol>{moves}</ol>
+          <ol style={{listStylePosition: "inside", margin: 0, padding: 0}}>{moves}</ol>
         </div>
       </div>
     );


### PR DESCRIPTION
## 어떤 변화를 만들고 싶은지, 뭐가 좋아지는 지(혹은 뭐가 나빴는지)
- 현재 Jump To History를 통해서 history를 변경하게 되면, 어느 history를 보고 있는지 가시성이 떨어진다
  - 내가 클릭한 위치를 기억해서 파악
  - 기억하지 못 할 경우, 보드에 놓인 말의 개수를 세어보고 파악

## 해결방안
  - CSS를 통해서 보고 있는 step에 해당하는 버튼에 border를 노란색으로 칠해준다

## 한 일

- 작은 변화 단위로 커밋
  - 커밋은 Done, Detail, To Do의 구조로 작성
- 특정 button을 클릭했을 때
  - style을 conditional하게 부여
  - 외부 css로 추출

## 마주했던 어려움

- ol에는 스타일이 적용되지 않음
  - li 뿐만 아니라 ol 에도 스타일이 적용될 수 있도록 하는 과정에서 참고한 [article](https://stackoverflow.com/questions/34616118/how-to-add-border-to-li-include-the-number/34616273)

## 변화

### 변경 전
![2017-07-10 3 39 54](https://user-images.githubusercontent.com/14256139/28005573-5d9cbf30-6586-11e7-8da3-a46a55cc962f.png)

### 변경 후
![2017-07-10 3 40 24](https://user-images.githubusercontent.com/14256139/28005577-60d2d91e-6586-11e7-9d83-d4f4433850f2.png)

---

## 배운 점

- 어떤 일을 왜, 무엇을 해야 하는 것인지 알아내는 것이 매우 중요하다
- 빠르고 성급하게 가 아닌, 천천히 올바르게
- 일을 최대한 쪼개서 진행해야 한다
- 내가 쓰려고 생각한 코드가 어떤 변화를 가져올지는 예상만 하지 말고, 직접 작성해서 결과를 봐야 한다 (가설 위 가설은 무의미)
  - 될 것 같은 코드도 안 되는 일이 비일비재하다
- 변화는 (되돌릴 수 있도록) 빼는 것보다 더하는 것이 선행되어야 한다
- 한 번의 커밋과 커밋 사이에는 한 번 또는 최소한의 변화만 줄 것
  - 5번 변화를 한 번에 주면 경우의 수가 32가지
- 커밋이 너무 많아서 문제라면, 원격 저장소로 Push하기 전에 rebase하면 그만
- 내가 생각해낸 방법이 그 전 project history와 align 된 것이 아니라면 필히 팀원들과 상의를 해서 결정할 것
- 커밋 = 변화 + 상세설명 + 앞으로 할 일
- 커밋 단위에 대한 내가 개발할 때 && 다른 분들이 리뷰할 때의 편의성을 모두 충족할 수 있는 적절한 호흡을 찾아야 함
- 브랜치명에는 _가 아닌 -를, css class name에는 hierarchy + 해당 요소 주변에서 얻은 정보를 조합해서 명명
- PR을 보낼 때는, 내 관점이 아닌, 내가 다른 사람의 PR을 볼 때를 떠올리며 작성할 것
- 없던 것을 새로 도입하는 것보다 있는 코드를 이해해보고 어떻게 활용할지 고민해볼 것
- VS Code를 통해 자동으로 TSC가 되도록 하고, react-scripts를 통해 변경사항을 반영하여 실행할 수 있음
- CSS는 자동으로 반영되지 않는다